### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 			"url": "https://raw.github.com/noelboss/featherlight/master/LICENSE"
 		}
 	],
-	"main": "Gruntfile.js",
+	"main": "release/featherlight.min.js",
 	"name": "featherlight",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Because the the "main" points to Gruntfile.js, `import featherlight from 'featherlight';` will make featherlight be the content of the Gruntfile.js file instead of the actual featherlight library.
